### PR TITLE
feat: add state change callback functions

### DIFF
--- a/README.kr.md
+++ b/README.kr.md
@@ -131,6 +131,7 @@ import { ScrollView } from 'react-native-gesture-handler';
 ```
 
 #### **`react-native-gesture-handler` 버전이 2.22.0 미만인 경우:**
+
 이전 버전에서는 `GestureHandlerRootView`와의 호환성 문제가 발생할 수 있습니다. 최신 버전으로 업데이트하세요.
 
 ```sh
@@ -180,6 +181,8 @@ import { ScrollView } from 'react-native-gesture-handler';
 
 7. **커스터마이징 가능한 애니메이션 속도**: topsheet 열기/닫기 애니메이션의 속도를 조정하여 더 부드럽거나 빠른 경험을 제공할 수 있습니다.
 
+8. **상태 변경 콜백 기능**: 시트 상태 변경을 감지하는 콜백 함수(확장, 축소, 상태 변경)를 제공하여 사용자 인터랙션에 따른 커스텀 액션을 구현할 수 있습니다.
+
 ## 사용법
 
 ```js
@@ -192,6 +195,12 @@ const MyComponent = () => {
       minHeightFactor={3}
       maxHeightFactor={1.5}
       showBtn={true}
+      // 상태 변경 콜백
+      onExpand={() => console.log('시트가 확장되었습니다')}
+      onCollapse={() => console.log('시트가 축소되었습니다')}
+      onChange={(isExpanded) =>
+        console.log(`시트가 ${isExpanded ? '확장' : '축소'} 상태입니다`)
+      }
       // 기타 props
       CollapsedContent={
         <View>
@@ -225,20 +234,23 @@ const MyComponent = () => {
 
 다음은 `TopSheet` 컴포넌트의 기본값입니다. 이 값들은 `props`로 변경하여 커스터마이징할 수 있습니다.
 
-| **속성**                | **기본값**    | **타입**  | **설명**                                                                                                                                                                                     |
-| ----------------------- | ------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `minHeightFactor`       | 6             | `number`  | 축소된 상태의 topsheet 높이입니다. 값이 작을수록 더 높은 topsheet가 됩니다. 이 값은 화면 높이를 나누어 최소 높이를 계산하는 데 사용됩니다 (예: `minSheetHeight = height / minHeightFactor`). |
-| `maxHeightFactor`       | 2             | `number`  | 확장된 상태의 topsheet 높이입니다. 값이 작을수록 더 낮은 topsheet가 됩니다. 이 값은 화면 높이를 나누어 최대 높이를 계산하는 데 사용됩니다 (예: `maxSheetHeight = height / maxHeightFactor`). |
-| `borderBackgroundColor` | 'transparent' | `string`  | 테두리 반경으로 인해 생성된 공백을 채울 배경 색상입니다. topsheet 아래의 콘텐츠에 배경 색상이 있다면, 그 배경 색상과 일치하도록 설정하면 공백을 가릴 수 있습니다.                            |
-| `topsheetColor`         | 'gray'        | `string`  | topsheet의 배경 색상입니다.                                                                                                                                                                  |
-| `btnColor`              | 'black'       | `string`  | 확장/축소 버튼의 배경 색상입니다.                                                                                                                                                            |
-| `btnHeight`             | 5             | `number`  | 확장/축소 버튼의 높이입니다.                                                                                                                                                                 |
-| `btnWidth`              | 50            | `number`  | 확장/축소 버튼의 너비입니다.                                                                                                                                                                 |
-| `touchableArea`         | 20            | `number`  | 확장/축소 버튼의 터치 가능한 영역의 높이입니다.                                                                                                                                              |
-| `radius`                | 20            | `number`  | topsheet의 모서리 반경(테두리 반경)입니다.                                                                                                                                                   |
-| `showBtn`               | `true`        | `boolean` | 확장/축소 버튼을 표시할지 여부입니다.                                                                                                                                                        |
-| `damping`               | 10            | `number`  | 스프링 애니메이션의 감쇠 값(얼마나 뚝 떨어지는지)을 설정합니다. **1과 100 사이의 값**이어야 하며, 기본값은 10입니다.                                                                         |
-| `stiffness`             | 400           | `number`  | 스프링 애니메이션의 강성 값(얼마나 빠르게 움직이는지)을 설정합니다. **1과 500 사이의 값**이어야 하며, 기본값은 400입니다.                                                                    |
+| **속성**                | **기본값**    | **타입**   | **설명**                                                                                                                                                                                     |
+| ----------------------- | ------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `minHeightFactor`       | 6             | `number`   | 축소된 상태의 topsheet 높이입니다. 값이 작을수록 더 높은 topsheet가 됩니다. 이 값은 화면 높이를 나누어 최소 높이를 계산하는 데 사용됩니다 (예: `minSheetHeight = height / minHeightFactor`). |
+| `maxHeightFactor`       | 2             | `number`   | 확장된 상태의 topsheet 높이입니다. 값이 작을수록 더 낮은 topsheet가 됩니다. 이 값은 화면 높이를 나누어 최대 높이를 계산하는 데 사용됩니다 (예: `maxSheetHeight = height / maxHeightFactor`). |
+| `borderBackgroundColor` | 'transparent' | `string`   | 테두리 반경으로 인해 생성된 공백을 채울 배경 색상입니다. topsheet 아래의 콘텐츠에 배경 색상이 있다면, 그 배경 색상과 일치하도록 설정하면 공백을 가릴 수 있습니다.                            |
+| `topsheetColor`         | 'gray'        | `string`   | topsheet의 배경 색상입니다.                                                                                                                                                                  |
+| `btnColor`              | 'black'       | `string`   | 확장/축소 버튼의 배경 색상입니다.                                                                                                                                                            |
+| `btnHeight`             | 5             | `number`   | 확장/축소 버튼의 높이입니다.                                                                                                                                                                 |
+| `btnWidth`              | 50            | `number`   | 확장/축소 버튼의 너비입니다.                                                                                                                                                                 |
+| `touchableArea`         | 20            | `number`   | 확장/축소 버튼의 터치 가능한 영역의 높이입니다.                                                                                                                                              |
+| `radius`                | 20            | `number`   | topsheet의 모서리 반경(테두리 반경)입니다.                                                                                                                                                   |
+| `showBtn`               | `true`        | `boolean`  | 확장/축소 버튼을 표시할지 여부입니다.                                                                                                                                                        |
+| `damping`               | 10            | `number`   | 스프링 애니메이션의 감쇠 값(얼마나 뚝 떨어지는지)을 설정합니다. **1과 100 사이의 값**이어야 하며, 기본값은 10입니다.                                                                         |
+| `stiffness`             | 400           | `number`   | 스프링 애니메이션의 강성 값(얼마나 빠르게 움직이는지)을 설정합니다. **1과 500 사이의 값**이어야 하며, 기본값은 400입니다.                                                                    |
+| `onExpand`              | `undefined`   | `function` | 시트가 완전히 확장되었을 때(하단 위치) 호출되는 콜백 함수입니다. 시트가 확장될 때 특정 액션을 트리거하는데 유용합니다.                                                                       |
+| `onCollapse`            | `undefined`   | `function` | 시트가 완전히 축소되었을 때(상단 위치) 호출되는 콜백 함수입니다. 시트가 축소될 때 특정 액션을 트리거하는데 유용합니다.                                                                       |
+| `onChange`              | `undefined`   | `function` | 현재 확장 상태(`isExpanded`)를 매개변수로 받는 콜백 함수입니다. 시트가 확장 및 축소 상태 사이를 전환할 때마다 호출됩니다.                                                                    |
 
 이 값들은 `TopSheet` 컴포넌트에 props로 전달하여 커스터마이징할 수 있습니다.
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Then, you can proceed with using `ScrollView` as usual:
 ```js
 import { ScrollView } from 'react-native-gesture-handler';
 ```
+
 ---
 
 ## Troubleshooting
@@ -188,6 +189,8 @@ This will resolve the conflict by ensuring that there is only one instance of `G
 
 7. **Customizable Animation Speed**: Adjust the speed of the top sheet's opening/closing animation for a smoother or faster experience.
 
+8. **Change Callbacks**: Listen to sheet state changes with callbacks for expand, collapse, and general state changes, enabling custom actions triggered by user interactions.
+
 ## Usage
 
 ```js
@@ -200,6 +203,12 @@ const MyComponent = () => {
       minHeightFactor={3}
       maxHeightFactor={1.5}
       showBtn={true}
+      // State change callbacks
+      onExpand={() => console.log('Sheet expanded')}
+      onCollapse={() => console.log('Sheet collapsed')}
+      onChange={(isExpanded) =>
+        console.log(`Sheet is ${isExpanded ? 'expanded' : 'collapsed'}`)
+      }
       // Other props
       CollapsedContent={
         <View>
@@ -232,20 +241,23 @@ See the [contributing guide](CONTRIBUTING.md) to learn how to contribute to the 
 
 The following are the default values for the `TopSheet` component, which you can customize:
 
-| **Property**            | **Default Value** | **Type**  | **Description**                                                                                                                                                                                                                     |
-| ----------------------- | ----------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `minHeightFactor`       | 6                 | `number`  | The height of the top sheet when collapsed. Smaller values result in taller sheets. This value divides the screen height to calculate the minimum height of the top sheet (e.g., `minSheetHeight = height / minHeightFactor`).      |
-| `maxHeightFactor`       | 2                 | `number`  | The height of the top sheet when expanded. Smaller values result in shorter sheets. This value divides the screen height to calculate the maximum height of the top sheet (e.g., `maxSheetHeight = height / maxHeightFactor`).      |
-| `borderBackgroundColor` | 'transparent'     | `string`  | The background color that will fill the area created by the border radius. If the content under the top sheet has a background color, set `borderBackgroundColor` to match it so the space created by the border radius is covered. |
-| `topsheetColor`         | 'gray'            | `string`  | The background color of the top sheet.                                                                                                                                                                                              |
-| `btnColor`              | 'black'           | `string`  | The background color of the toggle button.                                                                                                                                                                                          |
-| `btnHeight`             | 5                 | `number`  | The height of the toggle button.                                                                                                                                                                                                    |
-| `btnWidth`              | 50                | `number`  | The width of the toggle button.                                                                                                                                                                                                     |
-| `touchableArea`         | 20                | `number`  | The height of the touchable area for the toggle button.                                                                                                                                                                             |
-| `radius`                | 20                | `number`  | The radius (corner rounding) of the top sheet.                                                                                                                                                                                      |
-| `showBtn`               | `true`            | `boolean` | Whether or not to show the toggle button.                                                                                                                                                                                           |
-| `damping`               | 10                | `number`  | The damping of the spring animation (controls how bouncy it is). Must be a value between **1 and 100**. Default is 10.                                                                                                              |
-| `stiffness`             | 400               | `number`  | The stiffness of the spring animation (controls how fast it moves). Must be a value between **1 and 500**. Default is 400.                                                                                                          |
+| **Property**            | **Default Value** | **Type**   | **Description**                                                                                                                                                                                                                     |
+| ----------------------- | ----------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `minHeightFactor`       | 6                 | `number`   | The height of the top sheet when collapsed. Smaller values result in taller sheets. This value divides the screen height to calculate the minimum height of the top sheet (e.g., `minSheetHeight = height / minHeightFactor`).      |
+| `maxHeightFactor`       | 2                 | `number`   | The height of the top sheet when expanded. Smaller values result in shorter sheets. This value divides the screen height to calculate the maximum height of the top sheet (e.g., `maxSheetHeight = height / maxHeightFactor`).      |
+| `borderBackgroundColor` | 'transparent'     | `string`   | The background color that will fill the area created by the border radius. If the content under the top sheet has a background color, set `borderBackgroundColor` to match it so the space created by the border radius is covered. |
+| `topsheetColor`         | 'gray'            | `string`   | The background color of the top sheet.                                                                                                                                                                                              |
+| `btnColor`              | 'black'           | `string`   | The background color of the toggle button.                                                                                                                                                                                          |
+| `btnHeight`             | 5                 | `number`   | The height of the toggle button.                                                                                                                                                                                                    |
+| `btnWidth`              | 50                | `number`   | The width of the toggle button.                                                                                                                                                                                                     |
+| `touchableArea`         | 20                | `number`   | The height of the touchable area for the toggle button.                                                                                                                                                                             |
+| `radius`                | 20                | `number`   | The radius (corner rounding) of the top sheet.                                                                                                                                                                                      |
+| `showBtn`               | `true`            | `boolean`  | Whether or not to show the toggle button.                                                                                                                                                                                           |
+| `damping`               | 10                | `number`   | The damping of the spring animation (controls how bouncy it is). Must be a value between **1 and 100**. Default is 10.                                                                                                              |
+| `stiffness`             | 400               | `number`   | The stiffness of the spring animation (controls how fast it moves). Must be a value between **1 and 500**. Default is 400.                                                                                                          |
+| `onExpand`              | `undefined`       | `function` | A callback function that is triggered when the sheet is fully expanded (at bottom position). Useful for triggering actions when the sheet expands.                                                                                  |
+| `onCollapse`            | `undefined`       | `function` | A callback function that is triggered when the sheet is fully collapsed (at top position). Useful for triggering actions when the sheet collapses.                                                                                  |
+| `onChange`              | `undefined`       | `function` | A callback function that receives the current expansion state (`isExpanded`) as a parameter. This is called whenever the sheet transitions between expanded and collapsed states.                                                   |
 
 You can customize these values by passing them as props to the `TopSheet` component.
 
@@ -254,3 +266,7 @@ You can customize these values by passing them as props to the `TopSheet` compon
 MIT
 
 ---
+
+```
+
+```

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -2,6 +2,22 @@ import { View, StyleSheet, Text } from 'react-native';
 import { TopSheet } from '@yeonhub/react-native-top-sheet';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
+/**
+ * TopSheet Example
+ *
+ * This example demonstrates the usage of the TopSheet component.
+ * TopSheet is a customizable sheet that slides down from the top of the screen.
+ *
+ * Key features demonstrated:
+ * - Height control with minHeightFactor and maxHeightFactor
+ * - Custom styling with topsheetColor and btnColor
+ * - Button dimensions with btnHeight and btnWidth
+ * - Animation physics using damping and stiffness parameters
+ * - Different content for collapsed and expanded states
+ *
+ * The component supports gestures and can be dragged between states.
+ * Wrap the TopSheet in a GestureHandlerRootView to enable gesture functionality.
+ */
 export default function App() {
   return (
     <View style={styles.container}>
@@ -16,6 +32,11 @@ export default function App() {
           touchableArea={30}
           damping={100}
           stiffness={100}
+          onExpand={() => console.log('Expanded')}
+          onCollapse={() => console.log('Collapsed')}
+          onChange={(isExpanded) =>
+            console.log(`TopSheet is ${isExpanded ? 'expanded' : 'collapsed'}`)
+          }
           CollapsedContent={
             <View>
               <Text>CollapsedContent</Text>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yeonhub/react-native-top-sheet",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "A top sheet library for React-Native",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/src/animations/animatedStyles.ts
+++ b/src/animations/animatedStyles.ts
@@ -1,10 +1,30 @@
-import { useAnimatedStyle } from 'react-native-reanimated';
+import {
+  useAnimatedStyle,
+  useDerivedValue,
+  runOnJS,
+  type SharedValue,
+  useSharedValue,
+} from 'react-native-reanimated';
 
 export const useAnimatedSheetStyles = (
-  sheetHeight: any,
+  sheetHeight: SharedValue<number>,
   minSheetHeight: number,
-  maxSheetHeight: number
+  maxSheetHeight: number,
+  onChange?: (isExpanded: boolean) => void,
+  onExpand?: () => void,
+  onCollapse?: () => void
 ) => {
+  const lastCallbackState = useSharedValue({
+    wasExpanded: false,
+    wasCollapsed: true,
+    lastOnChangeValue: false,
+  });
+
+  const fullyExpandedThreshold = minSheetHeight + 2;
+  const fullyCollapsedThreshold = maxSheetHeight - 2;
+
+  const midPoint = (minSheetHeight + maxSheetHeight) / 2;
+
   const animatedStyles = useAnimatedStyle(() => ({
     height: sheetHeight.value,
   }));
@@ -24,5 +44,45 @@ export const useAnimatedSheetStyles = (
     return { opacity };
   });
 
-  return { animatedStyles, animatedOpacityShort, animatedOpacityLong };
+  const isExpanded = useDerivedValue(() => {
+    const isNearTop = sheetHeight.value <= fullyExpandedThreshold;
+    const isNearBottom = sheetHeight.value >= fullyCollapsedThreshold;
+
+    const currentlyExpanded = sheetHeight.value >= midPoint;
+
+    if (isNearTop && !lastCallbackState.value.wasCollapsed) {
+      lastCallbackState.value.wasCollapsed = true;
+      if (onCollapse) {
+        runOnJS(onCollapse)();
+      }
+    } else if (!isNearTop && lastCallbackState.value.wasCollapsed) {
+      lastCallbackState.value.wasCollapsed = false;
+    }
+
+    if (isNearBottom && !lastCallbackState.value.wasExpanded) {
+      lastCallbackState.value.wasExpanded = true;
+      if (onExpand) {
+        runOnJS(onExpand)();
+      }
+    } else if (!isNearBottom && lastCallbackState.value.wasExpanded) {
+      lastCallbackState.value.wasExpanded = false;
+    }
+
+    if (
+      onChange &&
+      currentlyExpanded !== lastCallbackState.value.lastOnChangeValue
+    ) {
+      lastCallbackState.value.lastOnChangeValue = currentlyExpanded;
+      runOnJS(onChange)(currentlyExpanded);
+    }
+
+    return currentlyExpanded;
+  });
+
+  return {
+    animatedStyles,
+    animatedOpacityShort,
+    animatedOpacityLong,
+    isExpanded,
+  };
 };

--- a/src/components/topsheet/TopSheet.tsx
+++ b/src/components/topsheet/TopSheet.tsx
@@ -30,6 +30,9 @@ const TopSheet = ({
   stiffness = TopSheetDefaults.stiffness,
   CollapsedContent,
   ExpandedContent,
+  onExpand,
+  onCollapse,
+  onChange,
 }: TopSheetProps): JSX.Element => {
   const { minFactor, maxFactor } = validateHeightFactors(
     minHeightFactor,
@@ -44,7 +47,14 @@ const TopSheet = ({
   const { sheetHeight, context } = useSheetState(minSheetHeight);
 
   const { animatedStyles, animatedOpacityShort, animatedOpacityLong } =
-    useAnimatedSheetStyles(sheetHeight, minSheetHeight, maxSheetHeight);
+    useAnimatedSheetStyles(
+      sheetHeight,
+      minSheetHeight,
+      maxSheetHeight,
+      onChange,
+      onExpand,
+      onCollapse
+    );
 
   const gesture = useSheetGestures(
     sheetHeight,
@@ -56,14 +66,14 @@ const TopSheet = ({
   );
 
   const toggleHeight = () => {
-    sheetHeight.value = withSpring(
-      sheetHeight.value === minSheetHeight ? maxSheetHeight : minSheetHeight,
-      {
-        damping: clampedDamping,
-        stiffness: clampedStiffness,
-        overshootClamping: true,
-      }
-    );
+    const isCurrentlyExpanded = sheetHeight.value <= minSheetHeight + 10;
+    const targetHeight = isCurrentlyExpanded ? maxSheetHeight : minSheetHeight;
+
+    sheetHeight.value = withSpring(targetHeight, {
+      damping: clampedDamping,
+      stiffness: clampedStiffness,
+      overshootClamping: true,
+    });
   };
 
   return (

--- a/src/components/topsheet/types.ts
+++ b/src/components/topsheet/types.ts
@@ -13,4 +13,7 @@ export interface TopSheetProps {
   stiffness?: number;
   CollapsedContent?: React.ReactNode;
   ExpandedContent?: React.ReactNode;
+  onExpand?: () => void;
+  onCollapse?: () => void;
+  onChange?: (isExpanded: boolean) => void;
 }

--- a/src/gestures/sheetGestures.ts
+++ b/src/gestures/sheetGestures.ts
@@ -1,9 +1,19 @@
 import { Gesture } from 'react-native-gesture-handler';
-import { withSpring } from 'react-native-reanimated';
+import { withSpring, type SharedValue } from 'react-native-reanimated';
 
+/**
+ * Creates a pan gesture handler for controlling the sheet
+ * @param sheetHeight - Shared value for the sheet height
+ * @param context - Shared value for gesture context
+ * @param minSheetHeight - Minimum allowed height for the sheet
+ * @param maxSheetHeight - Maximum allowed height for the sheet
+ * @param damping - Spring animation damping value
+ * @param stiffness - Spring animation stiffness value
+ * @return A configured pan gesture handler for the sheet
+ */
 export const useSheetGestures = (
-  sheetHeight: any,
-  context: any,
+  sheetHeight: SharedValue<number>,
+  context: SharedValue<{ y: number }>,
   minSheetHeight: number,
   maxSheetHeight: number,
   damping: number,
@@ -21,19 +31,13 @@ export const useSheetGestures = (
       );
     })
     .onEnd((e) => {
-      if (e.velocityY > 0) {
-        sheetHeight.value = withSpring(maxSheetHeight, {
-          damping,
-          stiffness,
-          overshootClamping: true,
-        });
-      } else {
-        sheetHeight.value = withSpring(minSheetHeight, {
-          damping,
-          stiffness,
-          overshootClamping: true,
-        });
-      }
+      const targetHeight = e.velocityY > 0 ? maxSheetHeight : minSheetHeight;
+
+      sheetHeight.value = withSpring(targetHeight, {
+        damping,
+        stiffness,
+        overshootClamping: true,
+      });
     });
 
   return gesture;

--- a/src/state/sheetState.ts
+++ b/src/state/sheetState.ts
@@ -1,5 +1,10 @@
 import { useSharedValue } from 'react-native-reanimated';
 
+/**
+ * Creates and manages the shared values for the sheet component
+ * @param minSheetHeight - The initial height of the sheet
+ * @return An object containing sheetHeight and context shared values
+ */
 export const useSheetState = (minSheetHeight: number) => {
   const sheetHeight = useSharedValue<number>(minSheetHeight);
   const context = useSharedValue<{ y: number }>({ y: 0 });

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,5 +1,11 @@
 import { DAMPING_RANGE, STIFFNESS_RANGE } from '../config/rangeConfig';
 
+/**
+ * Clamps a value within the predefined range for the specified parameter
+ * @param value - The value to be clamped
+ * @param name - The name of the parameter ('damping' or 'stiffness')
+ * @return The clamped value within the allowed range
+ */
 export const clampValue = (value: number, name: string) => {
   const range = name === 'damping' ? DAMPING_RANGE : STIFFNESS_RANGE;
   const { min, max } = range;
@@ -12,6 +18,12 @@ export const clampValue = (value: number, name: string) => {
   return Math.min(Math.max(value, min), max);
 };
 
+/**
+ * Validates the height factors to ensure proper sheet behavior
+ * @param minFactor - The minimum height factor
+ * @param maxFactor - The maximum height factor
+ * @return An object containing validated minFactor and maxFactor values
+ */
 export const validateHeightFactors = (minFactor: number, maxFactor: number) => {
   if (maxFactor >= minFactor) {
     console.warn(


### PR DESCRIPTION
- Add onExpand callback that triggers when sheet is fully expanded
- Add onCollapse callback that triggers when sheet is fully collapsed
- Add onChange callback that provides current expansion state
- Update documentation with new callback properties


| **Property**            | **Default Value** | **Type**   | **Description**                                                                                                                                                                                                                     |
| ----------------------- | ----------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `onExpand`              | `undefined`       | `function` | A callback function that is triggered when the sheet is fully expanded (at bottom position). Useful for triggering actions when the sheet expands.                                                                                  |
| `onCollapse`            | `undefined`       | `function` | A callback function that is triggered when the sheet is fully collapsed (at top position). Useful for triggering actions when the sheet collapses.                                                                                  |
| `onChange`              | `undefined`       | `function` | A callback function that receives the current expansion state (`isExpanded`) as a parameter. This is called whenever the sheet transitions between expanded and collapsed states.                                                   |
